### PR TITLE
Move to Python client

### DIFF
--- a/deploy-service/course-base.sh
+++ b/deploy-service/course-base.sh
@@ -1,0 +1,2 @@
+curl -sL https://raw.githubusercontent.com/datawire/forge/master/install.sh | INSTALL_DIR=~/.bin/forge sh
+docker run -d -p 5000:5000 --name registry registry:2

--- a/deploy-service/env-init.sh
+++ b/deploy-service/env-init.sh
@@ -1,5 +1,2 @@
-apt-get install -y python-minimal python-pip \
-&& pip install virtualenv \
-&& curl -sL https://raw.githubusercontent.com/datawire/forge/master/install.sh | INSTALL_DIR=${HOME}/forge sh \
-&& export PATH=$PATH:${HOME}/forge/bin \
+export PATH=$PATH:~/.bin/forge/bin \
 && git clone https://github.com/datawire/hello-webapp.git

--- a/deploy-service/index.json
+++ b/deploy-service/index.json
@@ -13,6 +13,7 @@
     ],
     "intro": {
       "text": "intro.md",
+      "courseBase": "course-base.sh",
       "code": "env-init.sh"
     },
     "finish": {
@@ -26,6 +27,6 @@
     "uilayout": "terminal"
   },
   "backend": {
-    "imageid": "kubernetes"
+    "imageid": "kubernetes-python"
   }
 }

--- a/deploy-service/intro.md
+++ b/deploy-service/intro.md
@@ -4,12 +4,6 @@ Are you a developer, and want to play around with Kubernetes?
 
 In this tutorial, we'll show you the basics of deploying a service into Kubernetes from source code to a running Kubernetes cluster.
 
-## Prerequisites
-
-Before you get started, you're going to need a Docker Hub account and your credentials.
-
 ## Get started!
 
 To get started with this tutorial, click on the Start Scenario button.
-
-Note: Your environment is being automatically configured, so please wait a few minutes to wait for the scenario configuration to finish (we need to install Python for our web app, and some utilities). You'll see a bunch of text scrolling by, so please wait until you see the shell prompt to begin.

--- a/deploy-service/step2.md
+++ b/deploy-service/step2.md
@@ -4,8 +4,8 @@ Let's run the container:
 
 `docker run -d -p 80:8080 hello-webapp:v1`{{execute}}
 
-(This command runs the container, and maps the container's port 8080 to the localhost port 80.) We can verify that the webapp is running successfully:
+(This command runs the container, and maps the container's port 8080 to the hosts port 80.) We can verify that the webapp is running successfully:
 
-`curl localhost`{{execute}}
+`curl host01`{{execute}}
 
-(We're now sending an HTTP request to port 80 on localhost, which then maps to the 8080 in the container.)
+(We're now sending an HTTP request to port 80 on host01, which then maps to the 8080 in the container.)

--- a/deploy-service/step4.md
+++ b/deploy-service/step4.md
@@ -2,18 +2,14 @@ In order for your Kubernetes cluster to run an image, it needs to get a copy of 
 
 We typically do this through a container registry: a central service that hosts images. There are dozens of options for container registries, for both on-premise and cloud-only use cases.
 
-In this tutorial, we're going to use one of the more popular registries, the Docker Hub. If you don't have an account already, create an account at https://hub.docker.com.
+In this tutorial, the Katacoda environment has provisioned a personal Docker Registry to store the built image. Set the URL for the Registry as an environment variable with the command:
 
-Once you have the account, set up your Docker instance with the appropriate credentials:
+`export REGISTRY=[[HOST_SUBDOMAIN]]-5000-[[KATACODA_HOST]].environments.katacoda.com`{{execute}}
 
-`docker login`{{execute}}
+In order to push the Docker Image to the registry, we need to create a tag for the Docker image that contains our Docker repository name.
 
-In order to push the Docker image to Docker Hub, we need to create a tag for the Docker image that contains our Docker repository name. By default, that repository is our user name.
+`docker tag hello-webapp:v1 $REGISTRY/hello-webapp:v1`{{execute}}
 
-`export DOCKER_USER=YOUR_USERNAME_HERE`{{execute}}
+Then, we can push the image we just created to the Docker Registry:
 
-`docker tag hello-webapp:v1 $DOCKER_USER/hello-webapp:v1`{{execute}}
-
-Then, we can push the image we just created to Docker Hub:
-
-`docker push $DOCKER_USER/hello-webapp:v1`{{execute}}
+`docker push $REGISTRY/hello-webapp:v1`{{execute}}

--- a/deploy-service/step5.md
+++ b/deploy-service/step5.md
@@ -1,8 +1,12 @@
 Now, let's actually get this service running in Kubernetes. We're going to need to update our `deployment.yaml` file to point to the image for our particular service. For the purposes of this exercise, we've templated our deployment file with the variable IMAGE_URL, which we'll then instantiate with a `sed` command:
 
-`sed -i -e 's@IMAGE_URL@'"$DOCKER_USER/hello-webapp:v1"'@' deployment.yaml`{{execute}}
+`sed -i -e 's@IMAGE_URL@'"$REGISTRY/hello-webapp:v1"'@' deployment.yaml`{{execute}}
 
 (f you run `cat deployment.yaml`{{execute}} you'll see that your specific Docker repository is now in the `deployment.yaml` file.)
+
+To gain access to the Kubernetes cluster, the Kubernetes configuration file needs to be downloaded from the master. The configuration file contains the IP addresses and certificates required to communicate securely with Kubernetes.
+
+`scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@host01:/root/.kube/config ~/.kube/`{{execute}}
 
 Now, we can run actually get the service running:
 
@@ -16,19 +20,19 @@ We can see the services running:
 
 ## Accessing the cluster
 
-Now, we want to send an HTTP request to the service. Most Kubernetes services are not exposed to the Internet, for obvious reasons. So we need to be able to access services that are running in the cluster directly. One way to do this is with port-forward.
-
-To set up port-forwarding, we need to first get the name of the pod that is running the container. (A pod is a grouping of containers. In this tutorial, we only deploy 1 container per pod, so we use them interchangeably. You can read more about pods [here](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/).)
+Now, we want to send an HTTP request to the service. Most Kubernetes services are not exposed to the Internet, for obvious reasons. So we need to be able to access services that are running in the cluster directly.
 
 `kubectl get pods`{{execute}}
 
-Now, set up the port forward. HINT: kubectl supports tab completion, so if you type the first few letters of the pod name and then [TAB], it will automatically fill in the full name of the pod.
+When the service was deployed, a dynamic NodePort was assigned to the Pod. This can be accessed via `kubectl get svc`{{execute}}
 
-`kubectl port-forward $POD_NAME 8080:8080 &`{{execute}}
+Store the port assigned as a variable for later use.
+
+`export PORT=$(kubectl get svc hello-webapp -o go-template='{{range.spec.ports}}{{if .nodePort}}{{.nodePort}}{{"\n"}}{{end}}{{end}}')`
 
 We can now send an HTTP request to the service:
 
-`curl localhost:8080`{{execute}}
+`curl host01:$PORT`{{execute}}
 
 You'll see the "Hello, World" message again. Congratulations, you've got your service running in Kubernetes!
 

--- a/deploy-service/step6.md
+++ b/deploy-service/step6.md
@@ -8,7 +8,15 @@ Luckily, [Forge](http://forge.sh?utm_source=katacoda&utm_medium=tutorial&utm_cam
 
 `forge setup`{{execute}}
 
-Use the default registry supplied, enter in your Docker Hub username/password, and use your username as the organization (the default). Now, type:
+To setup Forge, enter the URL for our Docker Registry: `[[HOST_SUBDOMAIN]]-5000-[[KATACODA_HOST]].environments.katacoda.com`{{execute}}
+
+Enter the username for the Registry, in this case `root`{{execute}}
+
+Enter the organization, again `root`{{execute}}
+
+Finally, enter `root`{{execute}}
+
+With Forge configured, type:
 
 `forge deploy`{{execute}}
 
@@ -18,14 +26,12 @@ This process will take a few moments as Kubernetes terminates the existing conta
 
 `kubectl get pods`{{execute}}
 
-You should see the original hello-webapp pod terminating, and a new hello-webapp initializing. We'll set up a new port-forward:
+As previously, obtain the NodePort assigned to our deployment.
 
-`kubectl port-forward $NEW_POD_NAME 8000:8080`{{execute}}
-
-(Don't forget about tab completion! We're also mapping to localhost:8000, because we already have a port-forward taking over localhost:8080. In a non-tutorial situation, you should just kill that process.)
+`export PORT=$(kubectl get svc hello-webapp -o go-template='{{range.spec.ports}}{{if .nodePort}}{{.nodePort}}{{"\n"}}{{end}}{{end}}')`
 
 Now, let's check out our new welcome message:
 
-`curl localhost:8000`{{execute}}
+`curl host01:$PORT`{{execute}}
 
 Congratulations! You've applied the basic concepts necessary for you to develop and deploy source code into Kubernetes.


### PR DESCRIPTION
- Move Registry to Katacoda to remove dependency on Docker Hub
- Move to NodePort over PortForwarding. PortForwarding has confused users in the past as it blocks the terminal.
- Use PreConfigured Python client